### PR TITLE
getSourceMapContent more robust: `''` ended up in the `urls` array breaking build

### DIFF
--- a/lib/get-sourcemap-content.js
+++ b/lib/get-sourcemap-content.js
@@ -11,6 +11,7 @@ module.exports = function getSourceMapContent(src, inFileDirname, relativePath, 
     urls.push(matchedUrl);
     src = srcURL.removeFrom(src);
   }
+  urls = urls.filter(Boolean);
   if (urls.length) {
     for (let i = urls.length - 1; i >= 0; --i) {
       let sourceMapPath = path.join(inFileDirname, urls[i]);


### PR DESCRIPTION
make sure srcURLs are truthy. see https://github.com/meirish/broccoli-uglify-sourcemap/commit/0395cb1097ff5b90d77b6a1daf68ece96cd8be47